### PR TITLE
feat/Implement Rider creation service and tests

### DIFF
--- a/rider-service/pom.xml
+++ b/rider-service/pom.xml
@@ -28,6 +28,7 @@
 	</scm>
 	<properties>
 		<java.version>21</java.version>
+		<org.mapstruct.version>1.5.5.Final</org.mapstruct.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -72,6 +73,11 @@
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
 			<version>2.5.0</version>
 		</dependency>
+		<dependency>
+			<groupId>org.mapstruct</groupId>
+			<artifactId>mapstruct</artifactId>
+			<version>${org.mapstruct.version}</version>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -82,8 +88,18 @@
 				<configuration>
 					<annotationProcessorPaths>
 						<path>
+							<groupId>org.mapstruct</groupId>
+							<artifactId>mapstruct-processor</artifactId>
+							<version>${org.mapstruct.version}</version>
+						</path>
+						<path>
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
+						</path>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok-mapstruct-binding</artifactId>
+							<version>0.2.0</version>
 						</path>
 					</annotationProcessorPaths>
 				</configuration>

--- a/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/config/SecurityConfig.java
+++ b/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/config/SecurityConfig.java
@@ -1,0 +1,15 @@
+package br.com.rastrodeliberdade.rider_service.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/dto/RiderInsertDto.java
+++ b/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/dto/RiderInsertDto.java
@@ -1,0 +1,24 @@
+package br.com.rastrodeliberdade.rider_service.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record RiderInsertDto(
+        @NotBlank
+        String fullName,
+        @NotBlank
+        @Email
+        String email,
+        @NotBlank
+        String bikerNickname,
+        @NotBlank
+        @Size(min=8, message="A senha deve ter no minimo 8 caracteres")
+        String password,
+        @NotBlank
+        String city,
+        @NotBlank
+        String state
+        
+) {
+}

--- a/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/dto/RiderSummaryDto.java
+++ b/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/dto/RiderSummaryDto.java
@@ -1,0 +1,10 @@
+package br.com.rastrodeliberdade.rider_service.dto;
+
+public record RiderSummaryDto(
+        String bikerNickname,
+        String email,
+        String city,
+        String state
+
+) {
+}

--- a/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/exception/BusinessException.java
+++ b/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/exception/BusinessException.java
@@ -1,0 +1,11 @@
+package br.com.rastrodeliberdade.rider_service.exception;
+
+public class BusinessException extends RuntimeException {
+    public BusinessException(String message) {
+        super(message);
+    }
+
+    public BusinessException(String message, Throwable cause){
+        super(message,cause);
+    }
+}

--- a/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/exception/ResourceNotFoundException.java
+++ b/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/exception/ResourceNotFoundException.java
@@ -1,0 +1,17 @@
+package br.com.rastrodeliberdade.rider_service.exception;
+
+import java.util.UUID;
+
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+
+    public ResourceNotFoundException(String resourceName, String fieldName,Object fieldValue){
+        super(String.format("%s não encontrado com %s: '%s'",resourceName,fieldName,fieldValue));
+    }
+
+    public ResourceNotFoundException(String resourceName, UUID id){
+        super(String.format("%s com ID %s não encontrado.", resourceName, id));
+    }
+}

--- a/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/exception/RestExceptionHandler.java
+++ b/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/exception/RestExceptionHandler.java
@@ -1,0 +1,70 @@
+package br.com.rastrodeliberdade.rider_service.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.Instant;
+
+@RestControllerAdvice
+public class RestExceptionHandler {
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<StandardError> resourceNotFound(ResourceNotFoundException e, HttpServletRequest request){
+        String error = "Recurso não encontrado";
+        HttpStatus status = HttpStatus.NOT_FOUND;
+        StandardError err = new StandardError(
+                Instant.now(),
+                status.value(),
+                error,
+                e.getMessage(),
+                request.getRequestURI()
+        );
+        return  ResponseEntity.status(status).body(err);
+    }
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<StandardError> businessException(BusinessException e, HttpServletRequest request){
+        String error = "Erro na regra de negócio";
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+        StandardError err = new StandardError(
+                Instant.now(),
+                status.value(),
+                error,
+                e.getMessage(),
+                request.getRequestURI()
+        );
+        return ResponseEntity.status(status).body(err);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<StandardError> validation(MethodArgumentNotValidException e, HttpServletRequest request){
+        String error = "Erro de validação";
+        HttpStatus status = HttpStatus.UNPROCESSABLE_ENTITY;
+        StandardError err = new StandardError(
+                Instant.now(),
+                status.value(),
+                error,
+                e.getMessage(),
+                request.getRequestURI()
+        );
+        return ResponseEntity.status(status).body(err);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<StandardError> genericException(Exception e, HttpServletRequest request){
+        String error = "Erro interno de servidor";
+        HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
+        StandardError err = new StandardError(
+                Instant.now(),
+                status.value(),
+                error,
+                e.getMessage(),
+                request.getRequestURI()
+        );
+        return ResponseEntity.status(status).body(err);
+    }
+}

--- a/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/exception/StandardError.java
+++ b/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/exception/StandardError.java
@@ -1,0 +1,21 @@
+package br.com.rastrodeliberdade.rider_service.exception;
+
+import lombok.*;
+
+import java.io.Serializable;
+import java.time.Instant;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class StandardError implements Serializable {
+    private static  final long serialVersionUID = 1L;
+
+    private Instant timestamp;
+    private Integer status;
+    private String error;
+    private String message;
+    private String path;
+}

--- a/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/mapper/RiderMapper.java
+++ b/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/mapper/RiderMapper.java
@@ -1,0 +1,16 @@
+package br.com.rastrodeliberdade.rider_service.mapper;
+
+import br.com.rastrodeliberdade.rider_service.domain.Rider;
+import br.com.rastrodeliberdade.rider_service.dto.RiderInsertDto;
+import br.com.rastrodeliberdade.rider_service.dto.RiderSummaryDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface RiderMapper {
+
+    RiderSummaryDto toSummaryDto(Rider rider);
+
+    @Mapping(target = "password", ignore = true)
+    Rider toRider(RiderInsertDto dto);
+}

--- a/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/service/RiderService.java
+++ b/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/service/RiderService.java
@@ -1,0 +1,43 @@
+package br.com.rastrodeliberdade.rider_service.service;
+
+import br.com.rastrodeliberdade.rider_service.domain.Rider;
+import br.com.rastrodeliberdade.rider_service.dto.RiderInsertDto;
+import br.com.rastrodeliberdade.rider_service.dto.RiderSummaryDto;
+import br.com.rastrodeliberdade.rider_service.exception.BusinessException;
+import br.com.rastrodeliberdade.rider_service.mapper.RiderMapper;
+import br.com.rastrodeliberdade.rider_service.repository.RiderRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RiderService {
+    @Autowired
+    private RiderRepository riderRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private RiderMapper riderMapper;
+
+    public RiderSummaryDto insertRider(RiderInsertDto riderInsertDto){
+        if(riderRepository.findByEmail(riderInsertDto.email()).isPresent()){
+            throw  new BusinessException("Já existe um  usuário cadastrado com o e-mail: "+riderInsertDto.email());
+        }
+
+        if(riderRepository.findByBikerNickname(riderInsertDto.bikerNickname()).isPresent()){
+            throw new BusinessException("já existe um usuário cadastrado com o nickname: "+riderInsertDto.bikerNickname());
+        }
+
+        Rider newRider = riderMapper.toRider(riderInsertDto);
+
+        newRider.setPassword(passwordEncoder.encode(riderInsertDto.password()));
+
+        Rider savedRider = riderRepository.save(newRider);
+
+        return riderMapper.toSummaryDto(savedRider);
+    }
+
+
+}

--- a/rider-service/src/test/java/br/com/rastrodeliberdade/rider_service/service/RiderServiceTest.java
+++ b/rider-service/src/test/java/br/com/rastrodeliberdade/rider_service/service/RiderServiceTest.java
@@ -1,0 +1,140 @@
+package br.com.rastrodeliberdade.rider_service.service;
+
+import br.com.rastrodeliberdade.rider_service.domain.Rider;
+import br.com.rastrodeliberdade.rider_service.dto.RiderInsertDto;
+import br.com.rastrodeliberdade.rider_service.dto.RiderSummaryDto;
+import br.com.rastrodeliberdade.rider_service.exception.BusinessException;
+import br.com.rastrodeliberdade.rider_service.mapper.RiderMapper;
+import br.com.rastrodeliberdade.rider_service.repository.RiderRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+public class RiderServiceTest {
+    @Autowired
+    RiderService riderService;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    @Autowired
+    RiderMapper riderMapper;
+
+    @MockitoBean
+    RiderRepository riderRepository;
+
+    @Test
+    @DisplayName("Should return new inserted Rider when call insert and everything is ok")
+    void insert_ReturnNewRider_WhenEverythingIsOk() throws Exception{
+        RiderInsertDto riderInsertDto = new RiderInsertDto(
+                "João Silva",
+                "joao.silva@test.com",
+                "joao.silva",
+                "12345mudar!",
+                "São Paulo",
+                "São Paulo"
+        );
+
+        Rider fakeSavedRider = Rider.builder()
+                .id(UUID.randomUUID())
+                .fullName(riderInsertDto.fullName())
+                .email(riderInsertDto.email())
+                .bikerNickname(riderInsertDto.bikerNickname())
+                .password(passwordEncoder.encode(riderInsertDto.password()))
+                .city(riderInsertDto.city())
+                .state(riderInsertDto.state())
+                .build();
+
+        RiderSummaryDto expectedRiderSummaryDto = riderMapper.toSummaryDto(fakeSavedRider);
+
+        when(riderRepository.findByEmail(riderInsertDto.email())).thenReturn(Optional.empty());
+        when(riderRepository.findByBikerNickname(riderInsertDto.bikerNickname())).thenReturn(Optional.empty());
+        when(riderRepository.save(any(Rider.class))).thenReturn(fakeSavedRider);
+
+        RiderSummaryDto resultInsertRider = riderService.insertRider(riderInsertDto);
+
+        assertThat(resultInsertRider).isNotNull();
+
+        assertThat(resultInsertRider.bikerNickname()).isEqualTo(expectedRiderSummaryDto.bikerNickname());
+        assertThat(resultInsertRider.email()).isEqualTo(expectedRiderSummaryDto.email());
+        assertThat(resultInsertRider.city()).isEqualTo(expectedRiderSummaryDto.city());
+        assertThat(resultInsertRider.state()).isEqualTo(expectedRiderSummaryDto.state());
+
+        verify(riderRepository,times(1)).findByEmail(riderInsertDto.email());
+        verify(riderRepository,times(1)).findByBikerNickname(riderInsertDto.bikerNickname());
+        verify(riderRepository,times(1)).save(any(Rider.class));
+
+    }
+
+    @Test
+    @DisplayName("Should return Business Exception when call insert with existing email")
+    void insert_ReturnBusinessException_WhenEmailAlreadyExists() throws Exception{
+        RiderInsertDto riderInsertDto = new RiderInsertDto(
+                "João Silva",
+                "joao.silva@test.com",
+                "joao.silva",
+                "12345mudar!",
+                "São Paulo",
+                "São Paulo"
+        );
+
+        Rider fakeSavedRider = Rider.builder()
+                .id(UUID.randomUUID())
+                .fullName(riderInsertDto.fullName())
+                .email(riderInsertDto.email())
+                .bikerNickname(riderInsertDto.bikerNickname())
+                .password(passwordEncoder.encode(riderInsertDto.password()))
+                .city(riderInsertDto.city())
+                .state(riderInsertDto.state())
+                .build();
+
+        when(riderRepository.findByEmail(riderInsertDto.email())).thenReturn(Optional.of(fakeSavedRider));
+
+        assertThatThrownBy(()->riderService.insertRider(riderInsertDto))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("Já existe um  usuário cadastrado com o e-mail: "+riderInsertDto.email());
+
+    }
+
+    @Test
+    @DisplayName("Should return Business Exception when call insert with existing rider nickname")
+    void insert_ReturnBusinessException_WhenNickNameAlreadyExists() throws Exception{
+        RiderInsertDto riderInsertDto = new RiderInsertDto(
+                "João Silva",
+                "joao.silva@test.com",
+                "joao.silva",
+                "12345mudar!",
+                "São Paulo",
+                "São Paulo"
+        );
+
+        Rider fakeSavedRider = Rider.builder()
+                .id(UUID.randomUUID())
+                .fullName(riderInsertDto.fullName())
+                .email(riderInsertDto.email())
+                .bikerNickname(riderInsertDto.bikerNickname())
+                .password(passwordEncoder.encode(riderInsertDto.password()))
+                .city(riderInsertDto.city())
+                .state(riderInsertDto.state())
+                .build();
+
+        when(riderRepository.findByEmail(riderInsertDto.email())).thenReturn(Optional.empty());
+        when(riderRepository.findByBikerNickname(riderInsertDto.bikerNickname())).thenReturn(Optional.of(fakeSavedRider));
+
+        assertThatThrownBy(()->riderService.insertRider(riderInsertDto))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("já existe um usuário cadastrado com o nickname: "+riderInsertDto.bikerNickname());
+
+    }
+}


### PR DESCRIPTION
## Description

This pull request implements the core business logic for creating a new `Rider` in the system. It introduces the `RiderService` which orchestrates the creation process and the `SecurityConfig` required for password handling.

This is the primary feature implementation, delivering a fully functional and tested vertical slice of the rider creation use case.

## Key Implementation Details

-   **`SecurityConfig.java`**:
    -   Configures the `PasswordEncoder` bean (`BCryptPasswordEncoder`) to be available for dependency injection, ensuring all passwords are securely hashed.
-   **`RiderService.java`**:
    -   Implements the `insertRider` method.
    -   **Business Rule**: Validates that the `email` and `bikerNickname` are unique before creating a new user, throwing a `BusinessException` if a duplicate is found.
    -   **Security**: Encrypts the user's plain-text password using the `PasswordEncoder` before saving the entity.
    -   Uses `RiderMapper` to handle conversions between DTOs and the `Rider` entity.

## Testing Strategy

-   **`RiderServiceTest.java`**:
    -   Provides full unit test coverage for the `RiderService`.
    -   The `RiderRepository` is mocked using `@MockitoBean` to isolate the service layer and test its logic independently of the database.
    -   Tests cover three scenarios:
        1.  Successful rider creation (the "happy path").
        2.  Failure due to a pre-existing email.
        3.  Failure due to a pre-existing biker nickname.

