### PR TITLE
feat/rider-service-findById

### DIFF
--- a/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/controller/RiderController.java
+++ b/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/controller/RiderController.java
@@ -17,6 +17,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping(value = "/rider")
@@ -47,5 +48,17 @@ public class RiderController {
         List<RiderSummaryDto> riderSummaryDtoList = riderService.findAllRider();
 
         return ResponseEntity.status(HttpStatus.OK).body(riderSummaryDtoList);
+    }
+
+    @Operation(summary = "Find Rider by Id",
+            description = "Endpoint find Rider by Id in the system")
+    @ApiResponse(responseCode = "200", description = "Success to find Rider",
+            content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = RiderSummaryDto.class)))
+    @GetMapping(value = "/{id}")
+    public ResponseEntity<RiderSummaryDto> findById(@PathVariable UUID id){
+        RiderSummaryDto resultRider = riderService.findById(id);
+
+        return ResponseEntity.status(HttpStatus.OK).body(resultRider);
     }
 }

--- a/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/service/RiderService.java
+++ b/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/service/RiderService.java
@@ -4,6 +4,7 @@ import br.com.rastrodeliberdade.rider_service.domain.Rider;
 import br.com.rastrodeliberdade.rider_service.dto.RiderInsertDto;
 import br.com.rastrodeliberdade.rider_service.dto.RiderSummaryDto;
 import br.com.rastrodeliberdade.rider_service.exception.BusinessException;
+import br.com.rastrodeliberdade.rider_service.exception.ResourceNotFoundException;
 import br.com.rastrodeliberdade.rider_service.mapper.RiderMapper;
 import br.com.rastrodeliberdade.rider_service.repository.RiderRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,6 +12,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 public class RiderService {
@@ -47,6 +49,13 @@ public class RiderService {
         return riders.stream()
                 .map(riderMapper::toSummaryDto)
                 .toList();
+    }
+
+    public RiderSummaryDto findById(UUID id){
+        Rider rider = riderRepository.findById(id)
+                .orElseThrow(()->new ResourceNotFoundException("Rider", id));
+
+        return riderMapper.toSummaryDto(rider);
     }
 
 

--- a/rider-service/src/test/java/br/com/rastrodeliberdade/rider_service/controller/RiderControllerIT.java
+++ b/rider-service/src/test/java/br/com/rastrodeliberdade/rider_service/controller/RiderControllerIT.java
@@ -17,6 +17,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.UUID;
+
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -150,5 +152,34 @@ public class RiderControllerIT {
                 .andExpect(jsonPath("$.[0].state").value(existingRider.getState()));
     }
 
+    @Test
+    @DisplayName("Should Return 200 Ok and RiderSummaryDto when call findById and everything is ok")
+    void findById_Return200OkAndRiderSummary_WhenEverythingIsOK() throws Exception{
+        UUID idToFind = existingRider.getId();
+
+        mockMvc.perform(get("/rider/{id}",idToFind)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.bikerNickname").value(existingRider.getBikerNickname()))
+                .andExpect(jsonPath("$.email").value(existingRider.getEmail()))
+                .andExpect(jsonPath("$.city").value(existingRider.getCity()))
+                .andExpect(jsonPath("$.state").value(existingRider.getState()));
+
+    }
+
+    @Test
+    @DisplayName("Should Return 404 and Resource Not Found Exception when call findById with non existing id")
+    void finById_ReturnResourceNotFoundException_WhenIdNonExisting() throws Exception{
+        UUID idToFind = UUID.randomUUID();
+
+        mockMvc.perform(get("/rider/{id}",idToFind)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.error").value("Recurso não encontrado"))
+                .andExpect(jsonPath("$.message").value("Rider com ID "+idToFind+" não encontrado."));
+    }
 
 }


### PR DESCRIPTION
## Description

This pull request introduces the functionality to retrieve a single Rider by their unique ID.

It adds a new `GET /rider/{id}` endpoint, the corresponding business logic in the service layer, and comprehensive testing across all layers to ensure correctness and robustness. Error handling for non-existent IDs is also included, returning a `404 Not Found` status as expected.

## Changes

* **feat(rider):** Added `GET /rider/{id}` endpoint to `RiderController` to fetch a rider by their UUID.
* **feat(rider):** Implemented the `findById(UUID id)` method in `RiderService`, which retrieves the entity from the database or throws a `ResourceNotFoundException` if not found.
* **test(rider):** Added unit tests in `RiderServiceTest` to cover both the successful retrieval and the `ResourceNotFoundException` scenario.
* **test(rider):** Added unit and integration tests in `RiderControllerTest` and `RiderControllerIT` to validate the endpoint's behavior for both `200 OK` and `404 Not Found` responses.
