### PR TITLE
refact(Rider): include Id in RiderSummaryDto and refactor tests

### DIFF
--- a/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/dto/RiderSummaryDto.java
+++ b/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/dto/RiderSummaryDto.java
@@ -1,6 +1,9 @@
 package br.com.rastrodeliberdade.rider_service.dto;
 
+import java.util.UUID;
+
 public record RiderSummaryDto(
+        UUID id,
         String bikerNickname,
         String email,
         String city,

--- a/rider-service/src/test/java/br/com/rastrodeliberdade/rider_service/controller/RiderControllerIT.java
+++ b/rider-service/src/test/java/br/com/rastrodeliberdade/rider_service/controller/RiderControllerIT.java
@@ -75,6 +75,7 @@ public class RiderControllerIT {
         );
 
         RiderSummaryDto expectedRiderSummaryDto = new RiderSummaryDto(
+                UUID.randomUUID(),
                 riderInsertDto.bikerNickname(),
                 riderInsertDto.email(),
                 riderInsertDto.city(),
@@ -86,6 +87,7 @@ public class RiderControllerIT {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(riderInsertDto)))
                 .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").isNotEmpty())
                 .andExpect(jsonPath("$.bikerNickname").value(riderInsertDto.bikerNickname()))
                 .andExpect(jsonPath("$.email").value(riderInsertDto.email()))
                 .andExpect(jsonPath("$.city").value(riderInsertDto.city()))
@@ -146,6 +148,7 @@ public class RiderControllerIT {
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.[0].id").value(existingRider.getId().toString()))
                 .andExpect(jsonPath("$.[0].bikerNickname").value(existingRider.getBikerNickname()))
                 .andExpect(jsonPath("$.[0].email").value(existingRider.getEmail()))
                 .andExpect(jsonPath("$.[0].city").value(existingRider.getCity()))
@@ -161,6 +164,7 @@ public class RiderControllerIT {
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(existingRider.getId().toString()))
                 .andExpect(jsonPath("$.bikerNickname").value(existingRider.getBikerNickname()))
                 .andExpect(jsonPath("$.email").value(existingRider.getEmail()))
                 .andExpect(jsonPath("$.city").value(existingRider.getCity()))

--- a/rider-service/src/test/java/br/com/rastrodeliberdade/rider_service/controller/RiderControllerTest.java
+++ b/rider-service/src/test/java/br/com/rastrodeliberdade/rider_service/controller/RiderControllerTest.java
@@ -79,6 +79,7 @@ public class RiderControllerTest {
         );
 
         RiderSummaryDto expectedRiderSummaryDto = new RiderSummaryDto(
+                UUID.randomUUID(),
                 riderInsertDto.bikerNickname(),
                 riderInsertDto.email(),
                 riderInsertDto.city(),
@@ -92,6 +93,7 @@ public class RiderControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(riderInsertDto)))
                 .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").isNotEmpty())
                 .andExpect(jsonPath("$.bikerNickname").value(riderInsertDto.bikerNickname()))
                 .andExpect(jsonPath("$.email").value(riderInsertDto.email()))
                 .andExpect(jsonPath("$.city").value(riderInsertDto.city()))
@@ -174,8 +176,8 @@ public class RiderControllerTest {
 
         List<Rider> existingRiderList = List.of(fakeRider1,fakeRider2);
 
-        RiderSummaryDto fakeDto1 = new RiderSummaryDto("joao.silva", "joao.silva@test.com", "Maringá", "Paraná");
-        RiderSummaryDto fakeDto2 = new RiderSummaryDto("paulo.carvalho", "paulo.carvalho@test.com", "Cascavel", "Paraná");
+        RiderSummaryDto fakeDto1 = new RiderSummaryDto(fakeRider1.getId(),"joao.silva", "joao.silva@test.com", "Maringá", "Paraná");
+        RiderSummaryDto fakeDto2 = new RiderSummaryDto(fakeRider2.getId(),"paulo.carvalho", "paulo.carvalho@test.com", "Cascavel", "Paraná");
 
         List<RiderSummaryDto> expectedRiderList = List.of(fakeDto1, fakeDto2);
 
@@ -189,6 +191,7 @@ public class RiderControllerTest {
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.[0].id").value(expectedRiderList.get(0).id().toString()))
                 .andExpect(jsonPath("$.[0].bikerNickname").value(expectedRiderList.get(0).bikerNickname()))
                 .andExpect(jsonPath("$.[0].email").value(expectedRiderList.get(0).email()))
                 .andExpect(jsonPath("$.[0].city").value(expectedRiderList.get(0).city()))
@@ -202,6 +205,7 @@ public class RiderControllerTest {
     @DisplayName("Should Return 200 Ok and RiderSummaryDto when call findById and everything is ok")
     void findById_Return200OkAndRiderSummary_WhenEverythingIsOK() throws Exception{
         RiderSummaryDto expectedResultRiderSummary = new RiderSummaryDto(
+                existingRider.getId(),
                 existingRider.getBikerNickname(),
                 existingRider.getEmail(),
                 existingRider.getCity(),
@@ -215,6 +219,7 @@ public class RiderControllerTest {
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(expectedResultRiderSummary.id().toString()))
                 .andExpect(jsonPath("$.bikerNickname").value(expectedResultRiderSummary.bikerNickname()))
                 .andExpect(jsonPath("$.email").value(expectedResultRiderSummary.email()))
                 .andExpect(jsonPath("$.city").value(expectedResultRiderSummary.city()))

--- a/rider-service/src/test/java/br/com/rastrodeliberdade/rider_service/service/RiderServiceTest.java
+++ b/rider-service/src/test/java/br/com/rastrodeliberdade/rider_service/service/RiderServiceTest.java
@@ -86,6 +86,7 @@ public class RiderServiceTest {
 
         assertThat(resultInsertRider).isNotNull();
 
+        assertThat(resultInsertRider.id()).isEqualTo(expectedRiderSummaryDto.id());
         assertThat(resultInsertRider.bikerNickname()).isEqualTo(expectedRiderSummaryDto.bikerNickname());
         assertThat(resultInsertRider.email()).isEqualTo(expectedRiderSummaryDto.email());
         assertThat(resultInsertRider.city()).isEqualTo(expectedRiderSummaryDto.city());


### PR DESCRIPTION
## Description

This pull request refactors the `RiderSummaryDto` to include the `id` field.

This change is a quality-of-life improvement for API clients, allowing them to easily reference a specific rider's UUID from summary views. This enables subsequent requests (like fetching details, updating, or deleting) without needing additional queries to find the ID.

## Changes Made

* **`refact(DTO)`:** Added the `id` field (`UUID`) to the `RiderSummaryDto` record.
* **`refact(Test)`:** Updated all affected unit and integration tests across the service and controller layers (`RiderServiceTest`, `RiderControllerTest`, `RiderControllerIT`).
    * Adjusted the instantiation of `RiderSummaryDto` in test setups.
    * Added `jsonPath` assertions to verify that the `id` field is present and correct in the API responses for the `POST /rider`, `GET /rider`, and `GET /rider/{id}` endpoints.

