### PR TITLE
feat/service-rider-findByEmail

### DIFF
--- a/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/controller/RiderController.java
+++ b/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/controller/RiderController.java
@@ -61,4 +61,16 @@ public class RiderController {
 
         return ResponseEntity.status(HttpStatus.OK).body(resultRider);
     }
+
+    @Operation(summary = "Find Rider by email",
+            description = "Endpoint find Rider by email in the system")
+    @ApiResponse(responseCode = "200", description = "Success to find Rider",
+            content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = RiderSummaryDto.class)))
+    @GetMapping(value = "/search/by-email")
+    public ResponseEntity<RiderSummaryDto> findByEmail(@RequestParam String email){
+        RiderSummaryDto resultRider = riderService.findByEmail(email);
+
+        return ResponseEntity.status(HttpStatus.OK).body(resultRider);
+    }
 }

--- a/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/service/RiderService.java
+++ b/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/service/RiderService.java
@@ -58,5 +58,12 @@ public class RiderService {
         return riderMapper.toSummaryDto(rider);
     }
 
+    public  RiderSummaryDto findByEmail(String email){
+        Rider rider = riderRepository.findByEmail(email)
+                .orElseThrow(()->new ResourceNotFoundException("Rider", "e-mail", email));
+
+        return riderMapper.toSummaryDto(rider);
+    }
+
 
 }

--- a/rider-service/src/test/java/br/com/rastrodeliberdade/rider_service/controller/RiderControllerIT.java
+++ b/rider-service/src/test/java/br/com/rastrodeliberdade/rider_service/controller/RiderControllerIT.java
@@ -3,6 +3,7 @@ package br.com.rastrodeliberdade.rider_service.controller;
 import br.com.rastrodeliberdade.rider_service.domain.Rider;
 import br.com.rastrodeliberdade.rider_service.dto.RiderInsertDto;
 import br.com.rastrodeliberdade.rider_service.dto.RiderSummaryDto;
+import br.com.rastrodeliberdade.rider_service.exception.ResourceNotFoundException;
 import br.com.rastrodeliberdade.rider_service.repository.RiderRepository;
 import br.com.rastrodeliberdade.rider_service.service.RiderService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -19,6 +20,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -184,6 +188,43 @@ public class RiderControllerIT {
                 .andExpect(jsonPath("$.status").value(404))
                 .andExpect(jsonPath("$.error").value("Recurso não encontrado"))
                 .andExpect(jsonPath("$.message").value("Rider com ID "+idToFind+" não encontrado."));
+    }
+
+    @Test
+    @DisplayName("Should Return 200 Ok and RiderSummaryDto when call findByEmail and everything is ok")
+    void findByEmail_Return200OkAndRiderSummary_WhenEverythingIsOK() throws Exception{
+        RiderSummaryDto expectedResultRiderSummary = new RiderSummaryDto(
+                existingRider.getId(),
+                existingRider.getBikerNickname(),
+                existingRider.getEmail(),
+                existingRider.getCity(),
+                existingRider.getState());
+
+        mockMvc.perform(get("/rider/search/by-email?email=carlos.antonio@test.com")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(expectedResultRiderSummary.id().toString()))
+                .andExpect(jsonPath("$.bikerNickname").value(expectedResultRiderSummary.bikerNickname()))
+                .andExpect(jsonPath("$.email").value(expectedResultRiderSummary.email()))
+                .andExpect(jsonPath("$.city").value(expectedResultRiderSummary.city()))
+                .andExpect(jsonPath("$.state").value(expectedResultRiderSummary.state()));
+
+    }
+
+    @Test
+    @DisplayName("Should Return 404 and Resource Not Found Exception when call findByEmail with non existing email")
+    void finByEmail_ReturnResourceNotFoundException_WhenEmailNonExisting() throws Exception{
+        String emailToFind = "testeerro@erro.com";
+
+        mockMvc.perform(get("/rider/search/by-email?email=testeerro@erro.com")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.error").value("Recurso não encontrado"))
+                .andExpect(jsonPath("$.message").value("Rider não encontrado com e-mail: '"+emailToFind+"'"));
+
     }
 
 }

--- a/rider-service/src/test/java/br/com/rastrodeliberdade/rider_service/controller/RiderControllerTest.java
+++ b/rider-service/src/test/java/br/com/rastrodeliberdade/rider_service/controller/RiderControllerTest.java
@@ -246,5 +246,50 @@ public class RiderControllerTest {
 
     }
 
+    @Test
+    @DisplayName("Should Return 200 Ok and RiderSummaryDto when call findByEmail and everything is ok")
+    void findByEmail_Return200OkAndRiderSummary_WhenEverythingIsOK() throws Exception{
+        RiderSummaryDto expectedResultRiderSummary = new RiderSummaryDto(
+                existingRider.getId(),
+                existingRider.getBikerNickname(),
+                existingRider.getEmail(),
+                existingRider.getCity(),
+                existingRider.getState());
+
+        String emailToFind = existingRider.getEmail();
+
+        given(riderService.findByEmail(emailToFind)).willReturn(expectedResultRiderSummary);
+
+        mockMvc.perform(get("/rider/search/by-email?email=marlonb@test.com")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(expectedResultRiderSummary.id().toString()))
+                .andExpect(jsonPath("$.bikerNickname").value(expectedResultRiderSummary.bikerNickname()))
+                .andExpect(jsonPath("$.email").value(expectedResultRiderSummary.email()))
+                .andExpect(jsonPath("$.city").value(expectedResultRiderSummary.city()))
+                .andExpect(jsonPath("$.state").value(expectedResultRiderSummary.state()));
+
+        verify(riderService,times(1)).findByEmail(emailToFind);
+
+    }
+
+    @Test
+    @DisplayName("Should Return 404 and Resource Not Found Exception when call findByEmail with non existing email")
+    void finByEmail_ReturnResourceNotFoundException_WhenEmailNonExisting() throws Exception{
+        String emailToFind = "testeerro@erro.com";
+
+        given(riderService.findByEmail(emailToFind)).willThrow(new ResourceNotFoundException("Rider", "e-mail", emailToFind));
+
+        mockMvc.perform(get("/rider/search/by-email?email=testeerro@erro.com")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.error").value("Recurso não encontrado"))
+                .andExpect(jsonPath("$.message").value("Rider não encontrado com e-mail: '"+emailToFind+"'"));
+
+    }
+
 
 }

--- a/rider-service/src/test/java/br/com/rastrodeliberdade/rider_service/service/RiderServiceTest.java
+++ b/rider-service/src/test/java/br/com/rastrodeliberdade/rider_service/service/RiderServiceTest.java
@@ -226,4 +226,34 @@ public class RiderServiceTest {
                 .hasMessageContaining("Rider com ID "+idToFind+" não encontrado.");
 
     }
+
+    @Test
+    @DisplayName("Should Return RiderSummaryDto when call findByEmail and everything is ok")
+    void findByEmail_ReturnRiderSummary_WhenEverythingIsOK() throws Exception{
+        RiderSummaryDto expectedResultRiderSummary = riderMapper.toSummaryDto(existingRider);
+
+        String emailToFind = existingRider.getEmail();
+
+        when(riderRepository.findByEmail(emailToFind)).thenReturn(Optional.ofNullable(existingRider));
+
+        RiderSummaryDto resultRiderSummary = riderService.findByEmail(emailToFind);
+
+        assertThat(resultRiderSummary).isEqualTo(expectedResultRiderSummary);
+
+        verify(riderRepository,times(1)).findByEmail(emailToFind);
+
+    }
+
+    @Test
+    @DisplayName("Should Return Resource Not Found Exception when call findByEmail with non existing email")
+    void finByEmail_ReturnResourceNotFoundException_WhenEmailNonExisting() throws Exception{
+        String emailToFind = "teste";
+
+        when(riderRepository.findByEmail(emailToFind)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(()->riderService.findByEmail(emailToFind))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("Rider não encontrado com e-mail: '"+emailToFind+"'");
+
+    }
 }


### PR DESCRIPTION
## Description

This pull request introduces a new feature that allows clients to find a specific Rider by their email address.

This provides a useful alternative to finding a user by their email, especially for validation purposes or user lookup scenarios. The implementation includes the service logic, a new RESTful endpoint, and comprehensive tests for both success and failure cases.

## Changes Made

* **`feat(Service)`:** Implemented the `findByEmail(String email)` method in `RiderService`, which includes logic to throw a `ResourceNotFoundException` if the email does not exist.
* **`feat(Controller)`:** Added a new endpoint `GET /rider/search/by-email` to `RiderController` that uses a `@RequestParam` to accept the email.
* **`test(Service)`:** Added unit tests in `RiderServiceTest` to verify the success and failure paths of the new service method.
* **`test(Controller)`:** Added both unit and integration tests (`RiderControllerTest` and `RiderControllerIT`) to validate the new endpoint, including checks for `200 OK` and `404 Not Found` responses.
