### PR TITLE
feat/rider-service-findByState

### DIFF
--- a/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/controller/RiderController.java
+++ b/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/controller/RiderController.java
@@ -73,4 +73,17 @@ public class RiderController {
 
         return ResponseEntity.status(HttpStatus.OK).body(resultRider);
     }
+
+    @Operation(summary = "Find Riders by state",
+            description = "Endpoint find Riders by state in the system")
+    @ApiResponse(responseCode = "200", description = "Success to find Riders by states",
+            content = @Content(mediaType = "application/json",
+                    array = @ArraySchema(schema = @Schema(implementation = RiderSummaryDto.class))))
+    @GetMapping(value = "/search/by-state")
+    public ResponseEntity<List<RiderSummaryDto>> findByState(@RequestParam String state){
+        List<RiderSummaryDto> riderSummaryDtoList = riderService.findByState(state);
+
+        return ResponseEntity.status(HttpStatus.OK).body(riderSummaryDtoList);
+
+    }
 }

--- a/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/service/RiderService.java
+++ b/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/service/RiderService.java
@@ -65,5 +65,13 @@ public class RiderService {
         return riderMapper.toSummaryDto(rider);
     }
 
+    public List<RiderSummaryDto> findByState(String state){
+        List<Rider> riders = riderRepository.findByState(state);
+
+        return riders.stream()
+                .map(riderMapper::toSummaryDto)
+                .toList();
+    }
+
 
 }

--- a/rider-service/src/test/java/br/com/rastrodeliberdade/rider_service/controller/RiderControllerIT.java
+++ b/rider-service/src/test/java/br/com/rastrodeliberdade/rider_service/controller/RiderControllerIT.java
@@ -227,4 +227,32 @@ public class RiderControllerIT {
 
     }
 
+    @Test
+    @DisplayName("Should return 200 Ok and a list of riders when call findByState and everything is ok")
+    void findByState_Return200OkAndListOfRiders_WhenEverythingIsOk() throws Exception {
+        String stateToFind = "São Paulo";
+
+        mockMvc.perform(get("/rider/search/by-state")
+                        .param("state", stateToFind)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.size()").value(1))
+                .andExpect(jsonPath("$.[0].id").value(existingRider.getId().toString()))
+                .andExpect(jsonPath("$.[0].state").value(stateToFind));
+    }
+
+    @Test
+    @DisplayName("Should return 200 Ok and an empty list when call findByState with a non-existing state")
+    void findByState_Return200OkAndEmptyList_WhenStateNonExisting() throws Exception {
+        String stateToFind = "Estado Inexistente";
+
+        mockMvc.perform(get("/rider/search/by-state")
+                        .param("state", stateToFind)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.size()").value(0));
+    }
+
 }

--- a/rider-service/src/test/java/br/com/rastrodeliberdade/rider_service/controller/RiderControllerTest.java
+++ b/rider-service/src/test/java/br/com/rastrodeliberdade/rider_service/controller/RiderControllerTest.java
@@ -291,5 +291,57 @@ public class RiderControllerTest {
 
     }
 
+    @Test
+    @DisplayName("Should return 200 Ok and a list of riders when call findByState and everything is ok")
+    void findByState_Return200OkAndListOfRiders_WhenEverythingIsOK() throws Exception {
+        String stateToFind = "Paraná";
+        RiderSummaryDto fakeDto1 = new RiderSummaryDto(
+                UUID.randomUUID(),
+                "joao.silva",
+                "joao.silva@test.com",
+                "Maringá",
+                stateToFind);
+
+        RiderSummaryDto fakeDto2 = new RiderSummaryDto(
+                UUID.randomUUID(),
+                "maria.santos",
+                "maria.santos@test.com",
+                "Curitiba",
+                stateToFind);
+
+        List<RiderSummaryDto> expectedRiderList = List.of(fakeDto1, fakeDto2);
+
+        given(riderService.findByState(stateToFind)).willReturn(expectedRiderList);
+
+        mockMvc.perform(get("/rider/search/by-state")
+                        .param("state", stateToFind)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.size()").value(2))
+                .andExpect(jsonPath("$.[0].bikerNickname").value("joao.silva"))
+                .andExpect(jsonPath("$.[1].bikerNickname").value("maria.santos"));
+
+        verify(riderService, times(1)).findByState(stateToFind);
+    }
+
+    @Test
+    @DisplayName("Should return 200 Ok and an empty list when call findByState with a non-existing state")
+    void findByState_Return200OkAndEmptyList_WhenStateNonExisting() throws Exception {
+        String stateToFind = "Estado Fantasma";
+        List<RiderSummaryDto> expectedRiderList = List.of();
+
+        given(riderService.findByState(stateToFind)).willReturn(expectedRiderList);
+
+        mockMvc.perform(get("/rider/search/by-state")
+                        .param("state", stateToFind)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.size()").value(0));
+
+        verify(riderService, times(1)).findByState(stateToFind);
+    }
+
 
 }

--- a/rider-service/src/test/java/br/com/rastrodeliberdade/rider_service/service/RiderServiceTest.java
+++ b/rider-service/src/test/java/br/com/rastrodeliberdade/rider_service/service/RiderServiceTest.java
@@ -256,4 +256,56 @@ public class RiderServiceTest {
                 .hasMessageContaining("Rider não encontrado com e-mail: '"+emailToFind+"'");
 
     }
+
+    @Test
+    @DisplayName("Should return a list of RiderSummaryDto when call findByState and everything is ok")
+    void findByState_ReturnListOfRider_WhenEverythingIsOK() {
+        String stateToFind = "Paraná";
+
+        Rider fakeRider1 = Rider.builder()
+                .id(UUID.randomUUID())
+                .fullName("João Silva")
+                .email("joao.silva@test.com")
+                .bikerNickname("joao.silva")
+                .state(stateToFind)
+                .build();
+
+        Rider fakeRider2 = Rider.builder()
+                .id(UUID.randomUUID())
+                .fullName("Maria Santos")
+                .email("maria.santos@test.com")
+                .bikerNickname("maria.santos")
+                .state(stateToFind)
+                .build();
+
+        List<Rider> existingRiderList = List.of(fakeRider1, fakeRider2);
+        List<RiderSummaryDto> expectedRiderList = existingRiderList.stream()
+                .map(riderMapper::toSummaryDto)
+                .toList();
+
+        when(riderRepository.findByState(stateToFind)).thenReturn(existingRiderList);
+
+        List<RiderSummaryDto> resultRiderList = riderService.findByState(stateToFind);
+
+        assertThat(resultRiderList).isNotNull();
+        assertThat(resultRiderList.size()).isEqualTo(2);
+        assertThat(resultRiderList).isEqualTo(expectedRiderList);
+
+        verify(riderRepository, times(1)).findByState(stateToFind);
+    }
+
+    @Test
+    @DisplayName("Should return an empty list when call findByState with non-existing state")
+    void findByState_ReturnEmptyList_WhenStateNonExisting() {
+        String stateToFind = "Estado Inexistente";
+
+        when(riderRepository.findByState(stateToFind)).thenReturn(List.of());
+
+        List<RiderSummaryDto> resultRiderList = riderService.findByState(stateToFind);
+
+        assertThat(resultRiderList).isNotNull();
+        assertThat(resultRiderList.isEmpty()).isTrue();
+
+        verify(riderRepository, times(1)).findByState(stateToFind);
+    }
 }


### PR DESCRIPTION
## Description

This pull request introduces a new feature that allows clients to search for and retrieve a list of Riders based on their state.

This adds a filtering capability to the API, which is useful for grouping and displaying users by location. The implementation includes the service logic, a new RESTful endpoint using a query parameter, and comprehensive unit and integration tests for all relevant scenarios.

## Changes Made

* **`feat(Service)`:** Implemented the `findByState(String state)` method in `RiderService`. This method correctly returns an empty list if no riders are found for the given state, which is the expected behavior for a collection filter.
* **`feat(Controller)`:** Added the new endpoint `GET /rider/search/by-state` to `RiderController`, which uses a `@RequestParam` to accept the state.
* **`test(Service)`:** Added unit tests in `RiderServiceTest` to verify the behavior for both when riders are found and when an empty list is returned.
* **`test(Controller)`:** Added both unit and integration tests (`RiderControllerTest` and `RiderControllerIT`) to validate the new endpoint, including checks for `200 OK` with a populated list and `200 OK` with an empty list.
