### PR TITLE
feat/rider-service-update

### DIFF
--- a/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/controller/RiderController.java
+++ b/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/controller/RiderController.java
@@ -86,4 +86,17 @@ public class RiderController {
         return ResponseEntity.status(HttpStatus.OK).body(riderSummaryDtoList);
 
     }
+
+    @Operation(summary = "Update an specif Rider",
+            description = "Endpoint to update an specif Rider in the system")
+    @ApiResponse(responseCode = "200", description = "Success to update an specif  Rider",
+            content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = RiderSummaryDto.class)))
+    @PutMapping(value = "/{id}")
+    public ResponseEntity<RiderSummaryDto> updated(@PathVariable UUID id, @Valid @RequestBody RiderInsertDto riderDto) {
+        RiderSummaryDto resultRiderDto = riderService.updateRider(riderDto,id);
+
+        return ResponseEntity.status(HttpStatus.OK).body(resultRiderDto);
+
+    }
 }

--- a/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/mapper/RiderMapper.java
+++ b/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/mapper/RiderMapper.java
@@ -5,6 +5,7 @@ import br.com.rastrodeliberdade.rider_service.dto.RiderInsertDto;
 import br.com.rastrodeliberdade.rider_service.dto.RiderSummaryDto;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 
 @Mapper(componentModel = "spring")
 public interface RiderMapper {
@@ -13,4 +14,7 @@ public interface RiderMapper {
 
     @Mapping(target = "password", ignore = true)
     Rider toRider(RiderInsertDto dto);
+
+    @Mapping(target = "password", ignore = true)
+    Rider updateRiderFromDto(RiderInsertDto dto, @MappingTarget Rider entity);
 }


### PR DESCRIPTION
## Description

This pull request implements the "Update" (the "U" in CRUD) functionality for the Rider resource.

It introduces a new `PUT /rider/{id}` endpoint that allows clients to update the details of an existing rider. The implementation includes business logic to prevent updating a rider with an email or nickname that already belongs to another user.

## Changes Made

* **`feat(Controller)`:** Added a `PUT /rider/{id}` endpoint to `RiderController`.
* **`feat(Service)`:** Implemented the `updateRider` method in `RiderService`, which contains the core logic for finding, validating, and saving the updated rider.
* **`feat(Mapper)`:** Added the `updateRiderFromDto` method to `RiderMapper`, utilizing `@MappingTarget` for efficient in-place entity updates.
* **`test(Service)`:** Added comprehensive unit tests in `RiderServiceTest` to cover the success path, `ResourceNotFoundException`, and `BusinessException` for duplicate email/nickname.
* **`test(Controller)`:** Added both unit and integration tests (`RiderControllerTest` and `RiderControllerIT`) to validate the new endpoint's behavior for `200 OK`, `404 Not Found`, and `400 Bad Request` responses.