### PR TITLE
feat/rider-service-delete

### DIFF
--- a/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/controller/RiderController.java
+++ b/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/controller/RiderController.java
@@ -99,4 +99,16 @@ public class RiderController {
         return ResponseEntity.status(HttpStatus.OK).body(resultRiderDto);
 
     }
+
+    @Operation(summary = "Delete an specif Rider",
+            description = "Endpoint to delete an specif Rider in the system")
+    @ApiResponse(responseCode = "204", description = "Success to delete an specif  Rider",
+            content = @Content(mediaType = "application/json"))
+    @DeleteMapping(value = "/{id}")
+    public ResponseEntity<Void> delete(@PathVariable UUID id) {
+        riderService.delete(id);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+
+    }
 }

--- a/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/service/RiderService.java
+++ b/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/service/RiderService.java
@@ -95,6 +95,14 @@ public class RiderService {
 
     }
 
+    @Transactional
+    public void delete(UUID id){
+        Rider riderToDelete = riderRepository.findById(id)
+                .orElseThrow(()->new ResourceNotFoundException("Rider",id));
+
+        riderRepository.delete(riderToDelete);
+    }
+
     private void validateIfEmailAlreadyRegisteredAnotherRider(String email, Rider rider){
         Optional<Rider> existingRider = riderRepository.findByEmail(email);
         if(existingRider.isPresent() && !(existingRider.get().getId().equals(rider.getId()))){

--- a/rider-service/src/test/java/br/com/rastrodeliberdade/rider_service/controller/RiderControllerIT.java
+++ b/rider-service/src/test/java/br/com/rastrodeliberdade/rider_service/controller/RiderControllerIT.java
@@ -361,4 +361,27 @@ public class RiderControllerIT {
                 .andExpect(jsonPath("$.message").value("Já existe um usuario diferente cadastrado com o nickname: " + riderUpdateDto.bikerNickname()));
     }
 
+    @Test
+    @DisplayName("Should return 204 No Content when call delete with an existing id")
+    void delete_Return204NoContent_WhenIdExists() throws Exception {
+        UUID idToDelete = existingRider.getId();
+
+        mockMvc.perform(delete("/rider/{id}", idToDelete)
+                        .with(csrf()))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("Should return 404 Not Found when call delete with a non-existing id")
+    void delete_Return404NotFound_WhenIdNonExisting() throws Exception {
+        UUID nonExistingId = UUID.randomUUID();
+
+        mockMvc.perform(delete("/rider/{id}", nonExistingId)
+                        .with(csrf()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.error").value("Recurso não encontrado"))
+                .andExpect(jsonPath("$.message").value("Rider com ID " + nonExistingId + " não encontrado."));
+    }
+
 }

--- a/rider-service/src/test/java/br/com/rastrodeliberdade/rider_service/controller/RiderControllerTest.java
+++ b/rider-service/src/test/java/br/com/rastrodeliberdade/rider_service/controller/RiderControllerTest.java
@@ -457,5 +457,35 @@ public class RiderControllerTest {
                 .andExpect(jsonPath("$.message").value(errorMessage));
     }
 
+    @Test
+    @DisplayName("Should return 204 No Content when call delete with an existing id")
+    void delete_Return204NoContent_WhenIdExists() throws Exception {
+        UUID idToDelete = existingRider.getId();
+        doNothing().when(riderService).delete(idToDelete);
+
+        mockMvc.perform(delete("/rider/{id}", idToDelete)
+                        .with(csrf()))
+                .andExpect(status().isNoContent());
+
+        verify(riderService, times(1)).delete(idToDelete);
+    }
+
+    @Test
+    @DisplayName("Should return 404 Not Found when call delete with a non-existing id")
+    void delete_Return404NotFound_WhenIdNonExisting() throws Exception {
+        UUID nonExistingId = UUID.randomUUID();
+        String expectedMessage = "Rider com ID " + nonExistingId + " não encontrado.";
+        doThrow(new ResourceNotFoundException("Rider", nonExistingId)).when(riderService).delete(nonExistingId);
+
+        mockMvc.perform(delete("/rider/{id}", nonExistingId)
+                        .with(csrf()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.error").value("Recurso não encontrado"))
+                .andExpect(jsonPath("$.message").value(expectedMessage));
+
+        verify(riderService, times(1)).delete(nonExistingId);
+    }
+
 
 }

--- a/rider-service/src/test/java/br/com/rastrodeliberdade/rider_service/service/RiderServiceTest.java
+++ b/rider-service/src/test/java/br/com/rastrodeliberdade/rider_service/service/RiderServiceTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.assertj.core.api.AssertionsForClassTypes.*;
 import static org.mockito.Mockito.*;
@@ -413,6 +414,33 @@ public class RiderServiceTest {
         assertThatThrownBy(() -> riderService.updateRider(riderUpdateDto, idToUpdate))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("Já existe um usuario diferente cadastrado com o nickname: " + riderUpdateDto.bikerNickname());
+    }
+
+    @Test
+    @DisplayName("Should complete successfully when call delete with an existing id")
+    void delete_ShouldCompleteSuccessfully_WhenIdExists() {
+        UUID idToDelete = existingRider.getId();
+        when(riderRepository.findById(idToDelete)).thenReturn(Optional.of(existingRider));
+        doNothing().when(riderRepository).delete(existingRider);
+
+        assertDoesNotThrow(() -> riderService.delete(idToDelete));
+
+        verify(riderRepository, times(1)).findById(idToDelete);
+        verify(riderRepository, times(1)).delete(existingRider);
+    }
+
+    @Test
+    @DisplayName("Should throw ResourceNotFoundException when call delete with a non-existing id")
+    void delete_ThrowResourceNotFoundException_WhenIdNonExisting() {
+        UUID idToDelete = UUID.randomUUID();
+        when(riderRepository.findById(idToDelete)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> riderService.delete(idToDelete))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("Rider com ID " + idToDelete + " não encontrado.");
+
+        verify(riderRepository, times(1)).findById(idToDelete);
+        verify(riderRepository, never()).delete(any(Rider.class));
     }
 
 


### PR DESCRIPTION
## Description

This pull request implements the "Delete" (the "D" in CRUD) functionality for the Rider resource, completing the core set of CRUD operations for the service.

It introduces a new `DELETE /rider/{id}` endpoint that allows clients to permanently remove a rider from the system. The implementation follows the "fetch-then-operate" pattern to ensure a `404 Not Found` is returned for non-existent IDs, and returns a `204 No Content` on successful deletion as per REST conventions.

## Changes Made

* **`feat(Service)`:** Implemented the `delete(UUID id)` method in `RiderService`, which finds the entity or throws a `ResourceNotFoundException`.
* **`feat(Controller)`:** Added a `DELETE /rider/{id}` endpoint to `RiderController` that returns a `204 No Content` status upon successful deletion.
* **`test(Service)`:** Added unit tests in `RiderServiceTest` to verify the success path and the `ResourceNotFoundException` scenario.
* **`test(Controller)`:** Added both unit and integration tests (`RiderControllerTest` and `RiderControllerIT`) to validate the new endpoint's behavior for both `204 No Content` (success) and `404 Not Found` (failure) responses.