### PR TITLE
chore(auth-service)-Configure-JWT-secret-and-expiration

### DIFF
--- a/auth-service/.gitignore
+++ b/auth-service/.gitignore
@@ -31,3 +31,7 @@ build/
 
 ### VS Code ###
 .vscode/
+
+# Secrets
+
+/src/main/resources/config/secrets.properties

--- a/auth-service/src/main/resources/application.properties
+++ b/auth-service/src/main/resources/application.properties
@@ -1,1 +1,5 @@
 spring.application.name=auth-service
+
+spring.config.import=optional:config/secrets.properties
+
+jwt.expiration=86400000 # 24 horas em milissegundos


### PR DESCRIPTION
## What does this PR do?
This PR refactors the configuration for the JWT secret key to enhance security. It moves the sensitive secret key out of the main `application.properties` file, preventing it from being committed into the Git version history.

## Why is this change necessary?
Hardcoding secrets in version control is a significant security risk. This new approach follows best practices by separating configuration from secrets, ensuring that sensitive data is not exposed in the repository.

