### PR TITLE
feat(auth-service): Implement TokenService for JWT generation

### DIFF
--- a/auth-service/pom.xml
+++ b/auth-service/pom.xml
@@ -71,6 +71,10 @@
 			<version>0.11.5</version>
 			<scope>runtime</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/auth-service/src/main/java/br/com/rastrodeliberdade/auth_service/service/TokenService.java
+++ b/auth-service/src/main/java/br/com/rastrodeliberdade/auth_service/service/TokenService.java
@@ -1,0 +1,38 @@
+package br.com.rastrodeliberdade.auth_service.service;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Service
+public class TokenService {
+
+    @Value("${jwt.secret}")
+    private String jwtSecret;
+
+    @Value("${jwt.expiration}")
+    private long jwtExpiration;
+
+    public String generateToken(Authentication authentication) {
+        UserDetails userPrincipal = (UserDetails) authentication.getPrincipal();
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + jwtExpiration);
+
+        SecretKey key = Keys.hmacShaKeyFor(jwtSecret.getBytes(StandardCharsets.UTF_8));
+
+        return Jwts.builder()
+                .setSubject(userPrincipal.getUsername())
+                .setIssuedAt(new Date())
+                .setExpiration(expiryDate)
+                .signWith(key,SignatureAlgorithm.HS512)
+                .compact();
+    }
+}

--- a/auth-service/src/test/java/br/com/rastrodeliberdade/auth_service/service/TokenServiceTest.java
+++ b/auth-service/src/test/java/br/com/rastrodeliberdade/auth_service/service/TokenServiceTest.java
@@ -1,0 +1,79 @@
+package br.com.rastrodeliberdade.auth_service.service;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.context.TestPropertySource;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+
+@SpringBootTest
+@TestPropertySource(properties = {
+        "jwt.secret=minha-chave-secreta-super-longa-para-testes-de-hs512-nao-usar-em-producao",
+        "jwt.expiration=60000"
+})
+public class TokenServiceTest {
+
+    @Autowired
+    private TokenService tokenService;
+
+    @Value("${jwt.secret}")
+    private String testJwtSecret;
+
+    private Authentication authentication;
+    private String userEmail = "teste@rastrodeliberdade.com";
+
+    @BeforeEach
+    void setUp() {
+        UserDetails userDetails = new User(
+                userEmail,
+                "qualquer-senha",
+                Collections.emptyList());
+
+        authentication = Mockito.mock(Authentication.class);
+        when(authentication.getPrincipal()).thenReturn(userDetails);
+    }
+
+    @Test
+    @DisplayName("Should generate a valid JWT when given a correct authentication")
+    void generateToken_withValidAuthentication_shouldReturnValidJwt() {
+        String token = tokenService.generateToken(authentication);
+
+        assertThat(token).isNotNull().isNotBlank();
+
+        SecretKey key = Keys.hmacShaKeyFor(testJwtSecret.getBytes(StandardCharsets.UTF_8));
+
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        assertThat(claims.getSubject()).isEqualTo(userEmail);
+    }
+
+    @Test
+    @DisplayName("Should throw NullPointerException when authentication is null")
+    void generateToken_withNullAuthentication_shouldThrowNullPointerException() {
+        assertThrows(NullPointerException.class, () -> {
+            tokenService.generateToken(null);
+        });
+    }
+}


### PR DESCRIPTION
## What does this PR do?
This PR introduces the `TokenService`, a core component responsible for generating JSON Web Tokens (JWTs) for authenticated users.

This implementation includes a comprehensive unit test suite to ensure the service is reliable and behaves as expected under different scenarios.

## Why is this change necessary?
The `TokenService` is a foundational piece of the `auth-service`. It enables our system to issue secure, stateless authentication tokens, which is the main requirement for the upcoming `/login` functionality.