### PR TITLE
feat(auth-service)-Implement-/login-endpoint

### DIFF
--- a/auth-service/pom.xml
+++ b/auth-service/pom.xml
@@ -75,6 +75,11 @@
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.8.6</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/auth-service/src/main/java/br/com/rastrodeliberdade/auth_service/config/SecurityConfig.java
+++ b/auth-service/src/main/java/br/com/rastrodeliberdade/auth_service/config/SecurityConfig.java
@@ -1,0 +1,39 @@
+package br.com.rastrodeliberdade.auth_service.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/login").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/auth-service/src/main/java/br/com/rastrodeliberdade/auth_service/controller/AuthController.java
+++ b/auth-service/src/main/java/br/com/rastrodeliberdade/auth_service/controller/AuthController.java
@@ -1,0 +1,41 @@
+package br.com.rastrodeliberdade.auth_service.controller;
+
+import br.com.rastrodeliberdade.auth_service.dto.LoginRequestDto;
+import br.com.rastrodeliberdade.auth_service.dto.LoginResponseDto;
+import br.com.rastrodeliberdade.auth_service.service.TokenService;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/login")
+public class AuthController {
+
+    @Autowired
+    private AuthenticationManager authenticationManager;
+
+    @Autowired
+    private TokenService tokenService;
+
+    @Operation(summary = "Authenticate a user",
+            description = "Endpoint to authenticate a user with email and password, returning a JWT if successful.")
+    @PostMapping
+    public ResponseEntity<LoginResponseDto> login(@RequestBody LoginRequestDto loginRequestDto) {
+        var usernamePassword = new UsernamePasswordAuthenticationToken(
+                loginRequestDto.email(),
+                loginRequestDto.password());
+
+        Authentication auth = authenticationManager.authenticate(usernamePassword);
+
+        String token = tokenService.generateToken(auth);
+
+        return ResponseEntity.ok(new LoginResponseDto(token));
+    }
+}

--- a/auth-service/src/main/resources/application.properties
+++ b/auth-service/src/main/resources/application.properties
@@ -2,4 +2,4 @@ spring.application.name=auth-service
 
 spring.config.import=optional:config/secrets.properties
 
-jwt.expiration=86400000 # 24 horas em milissegundos
+jwt.expiration=86400000 

--- a/auth-service/src/test/java/br/com/rastrodeliberdade/auth_service/controller/AuthControllerIT.java
+++ b/auth-service/src/test/java/br/com/rastrodeliberdade/auth_service/controller/AuthControllerIT.java
@@ -1,0 +1,85 @@
+package br.com.rastrodeliberdade.auth_service.controller;
+
+import br.com.rastrodeliberdade.auth_service.dto.LoginRequestDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class AuthControllerIT {
+    @TestConfiguration
+    static class TestUserDetailsService {
+        @Bean
+        public UserDetailsService userDetailsService() {
+            UserDetails user = User.builder()
+                    .username("user.test@rastro.com")
+                    .password(new BCryptPasswordEncoder().encode("password123"))
+                    .roles("USER")
+                    .build();
+            return new InMemoryUserDetailsManager(user);
+        }
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("Integration Test: Should return 200 OK and a JWT when login is successful")
+    void login_withValidCredentials_shouldReturnToken() throws Exception {
+        LoginRequestDto loginRequest = new LoginRequestDto("user.test@rastro.com", "password123");
+
+        mockMvc.perform(post("/login")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.token").exists())
+                .andExpect(jsonPath("$.token").isString())
+                .andExpect(jsonPath("$.token").isNotEmpty());
+    }
+
+    @Test
+    @DisplayName("Integration Test: Should return 403 Forbidden for incorrect password")
+    void login_withIncorrectPassword_shouldReturnForbidden() throws Exception {
+        LoginRequestDto loginRequest = new LoginRequestDto("user.test@rastro.com", "wrong-password");
+
+        mockMvc.perform(post("/login")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Integration Test: Should return 403 Forbidden for non-existent user")
+    void login_withNonExistentUser_shouldReturnForbidden() throws Exception {
+        LoginRequestDto loginRequest = new LoginRequestDto("ghost@rastro.com", "any-password");
+
+        mockMvc.perform(post("/login")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/auth-service/src/test/java/br/com/rastrodeliberdade/auth_service/controller/AuthControllerTest.java
+++ b/auth-service/src/test/java/br/com/rastrodeliberdade/auth_service/controller/AuthControllerTest.java
@@ -1,0 +1,75 @@
+package br.com.rastrodeliberdade.auth_service.controller;
+
+import br.com.rastrodeliberdade.auth_service.config.SecurityConfig;
+import br.com.rastrodeliberdade.auth_service.dto.LoginRequestDto;
+import br.com.rastrodeliberdade.auth_service.service.TokenService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuthController.class)
+@Import(SecurityConfig.class)
+public class AuthControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private AuthenticationManager authenticationManager;
+
+    @MockitoBean
+    private TokenService tokenService;
+
+
+    @Test
+    @DisplayName("Should return 200 OK and a JWT when login is successful")
+    void login_withValidCredentials_shouldReturnToken() throws Exception {
+        LoginRequestDto loginRequest = new LoginRequestDto("user@test.com", "password123");
+        String fakeToken = "fake-jwt-token";
+
+        Authentication authMock = mock(Authentication.class);
+        when(authenticationManager.authenticate(any())).thenReturn(authMock);
+        when(tokenService.generateToken(authMock)).thenReturn(fakeToken);
+
+        mockMvc.perform(post("/login")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.token").value(fakeToken));
+    }
+
+    @Test
+    @DisplayName("Should return 403 Forbidden when credentials are invalid")
+    void login_withInvalidCredentials_shouldReturnForbidden() throws Exception {
+        LoginRequestDto loginRequest = new LoginRequestDto("user@test.com", "wrong-password");
+
+        when(authenticationManager.authenticate(any()))
+                .thenThrow(new BadCredentialsException("Invalid credentials"));
+
+        mockMvc.perform(post("/login")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isForbidden());
+    }
+}


### PR DESCRIPTION
## What does this PR do?
This Pull Request implements the `POST /login` endpoint, which is the core functionality of the `auth-service`. This allows a client to submit user credentials (email and password) and receive a JWT upon successful authentication.

The implementation includes the controller, the necessary Spring Security configuration, and a comprehensive test suite covering both unit and integration scenarios.

## Why is this change necessary?
This endpoint is the primary entry point for users to authenticate with the "Rastro de Liberdade" ecosystem. It completes the initial setup of the authentication service, making it a functional, albeit standalone, component.

## How was it implemented?
- **`AuthController`**: A new REST controller was created to handle requests on the `/login` path. It orchestrates the authentication process by using the `AuthenticationManager` and the `TokenService`.

- **`SecurityConfig`**: A security configuration class was added to:
    - Expose the `AuthenticationManager` as a Spring Bean.
    - Configure a `BCryptPasswordEncoder` bean for password hashing.
    - Set up stateless session management (`SessionCreationPolicy.STATELESS`).
    - Define security rules, permitting public access to `/login` while securing all other endpoints.

- **Testing Strategy**: A robust, two-layer testing strategy was implemented:
    - **`AuthControllerTest.java` (Unit Test)**: Tests the controller in isolation (`@WebMvcTest`), mocking its dependencies to verify its internal logic and request handling.
    - **`AuthControllerIT.java` (Integration Test)**: Tests the end-to-end flow (`@SpringBootTest`), including the full Spring Security filter chain. It uses an in-memory `UserDetailsService` to simulate a real user database for a complete and realistic test of the login process.