### PR TITLE
feat(rider-service)/expose-auth-data

### DIFF
--- a/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/controller/RiderController.java
+++ b/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/controller/RiderController.java
@@ -1,6 +1,7 @@
 package br.com.rastrodeliberdade.rider_service.controller;
 
 
+import br.com.rastrodeliberdade.rider_service.dto.RiderAuthDto;
 import br.com.rastrodeliberdade.rider_service.dto.RiderInsertDto;
 import br.com.rastrodeliberdade.rider_service.dto.RiderSummaryDto;
 import br.com.rastrodeliberdade.rider_service.service.RiderService;
@@ -110,5 +111,18 @@ public class RiderController {
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
 
+    }
+
+    @Operation(summary = "Find Rider authentication data by email",
+            description = "INTERNAL USE ONLY - Endpoint to find Rider auth data by email for the auth-service",
+            hidden = true)
+    @ApiResponse(responseCode = "200", description = "Success to find Rider auth data",
+            content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = RiderAuthDto.class)))
+    @GetMapping(value = "/internal/by-email")
+    public ResponseEntity<RiderAuthDto> findAuthDataByEmail(@RequestParam String email){
+        RiderAuthDto resultRider = riderService.findAuthDataByEmail(email);
+
+        return ResponseEntity.status(HttpStatus.OK).body(resultRider);
     }
 }

--- a/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/dto/RiderAuthDto.java
+++ b/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/dto/RiderAuthDto.java
@@ -1,0 +1,10 @@
+package br.com.rastrodeliberdade.rider_service.dto;
+
+import java.util.UUID;
+
+public record RiderAuthDto(
+        UUID id,
+        String email,
+        String password
+) {
+}

--- a/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/mapper/RiderMapper.java
+++ b/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/mapper/RiderMapper.java
@@ -1,6 +1,7 @@
 package br.com.rastrodeliberdade.rider_service.mapper;
 
 import br.com.rastrodeliberdade.rider_service.domain.Rider;
+import br.com.rastrodeliberdade.rider_service.dto.RiderAuthDto;
 import br.com.rastrodeliberdade.rider_service.dto.RiderInsertDto;
 import br.com.rastrodeliberdade.rider_service.dto.RiderSummaryDto;
 import org.mapstruct.Mapper;
@@ -12,9 +13,12 @@ public interface RiderMapper {
 
     RiderSummaryDto toSummaryDto(Rider rider);
 
+    RiderAuthDto toAuthDto(Rider rider);
+
     @Mapping(target = "password", ignore = true)
     Rider toRider(RiderInsertDto dto);
 
     @Mapping(target = "password", ignore = true)
     Rider updateRiderFromDto(RiderInsertDto dto, @MappingTarget Rider entity);
+
 }

--- a/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/service/RiderService.java
+++ b/rider-service/src/main/java/br/com/rastrodeliberdade/rider_service/service/RiderService.java
@@ -1,6 +1,7 @@
 package br.com.rastrodeliberdade.rider_service.service;
 
 import br.com.rastrodeliberdade.rider_service.domain.Rider;
+import br.com.rastrodeliberdade.rider_service.dto.RiderAuthDto;
 import br.com.rastrodeliberdade.rider_service.dto.RiderInsertDto;
 import br.com.rastrodeliberdade.rider_service.dto.RiderSummaryDto;
 import br.com.rastrodeliberdade.rider_service.exception.BusinessException;
@@ -101,6 +102,14 @@ public class RiderService {
                 .orElseThrow(()->new ResourceNotFoundException("Rider",id));
 
         riderRepository.delete(riderToDelete);
+    }
+
+    public RiderAuthDto findAuthDataByEmail(String email){
+        Rider rider = riderRepository.findByEmail(email)
+                .orElseThrow(()-> new ResourceNotFoundException("Rider", "e-mail", email));
+
+        return riderMapper.toAuthDto(rider);
+
     }
 
     private void validateIfEmailAlreadyRegisteredAnotherRider(String email, Rider rider){

--- a/rider-service/src/test/java/br/com/rastrodeliberdade/rider_service/controller/RiderControllerIT.java
+++ b/rider-service/src/test/java/br/com/rastrodeliberdade/rider_service/controller/RiderControllerIT.java
@@ -384,4 +384,31 @@ public class RiderControllerIT {
                 .andExpect(jsonPath("$.message").value("Rider com ID " + nonExistingId + " não encontrado."));
     }
 
+    @Test
+    @DisplayName("IT: Should return 200 OK and RiderAuthDto when findAuthDataByEmail is called with an existing email")
+    void findAuthDataByEmail_withExistingEmail_shouldReturnOkAndRiderAuthDto() throws Exception {
+        String existingEmail = existingRider.getEmail();
+
+        mockMvc.perform(get("/rider/internal/by-email")
+                        .param("email", existingEmail)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(existingRider.getId().toString()))
+                .andExpect(jsonPath("$.email").value(existingEmail))
+                .andExpect(jsonPath("$.password").value(existingRider.getPassword()));
+    }
+
+    @Test
+    @DisplayName("IT: Should return 404 Not Found when findAuthDataByEmail is called with a non-existing email")
+    void findAuthDataByEmail_withNonExistingEmail_shouldReturnNotFound() throws Exception {
+        String nonExistingEmail = "ghost@test.com";
+
+        mockMvc.perform(get("/rider/internal/by-email")
+                        .param("email", nonExistingEmail)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+    }
+
 }

--- a/rider-service/src/test/java/br/com/rastrodeliberdade/rider_service/controller/RiderControllerTest.java
+++ b/rider-service/src/test/java/br/com/rastrodeliberdade/rider_service/controller/RiderControllerTest.java
@@ -1,6 +1,7 @@
 package br.com.rastrodeliberdade.rider_service.controller;
 
 import br.com.rastrodeliberdade.rider_service.domain.Rider;
+import br.com.rastrodeliberdade.rider_service.dto.RiderAuthDto;
 import br.com.rastrodeliberdade.rider_service.dto.RiderInsertDto;
 import br.com.rastrodeliberdade.rider_service.dto.RiderSummaryDto;
 import br.com.rastrodeliberdade.rider_service.exception.BusinessException;
@@ -485,6 +486,38 @@ public class RiderControllerTest {
                 .andExpect(jsonPath("$.message").value(expectedMessage));
 
         verify(riderService, times(1)).delete(nonExistingId);
+    }
+
+    @Test
+    @DisplayName("Should return 200 OK and RiderAuthDto when findAuthDataByEmail is called with an existing email")
+    void findAuthDataByEmail_withExistingEmail_shouldReturnOkAndRiderAuthDto() throws Exception {
+        String existingEmail = "marlonb@test.com";
+        RiderAuthDto expectedAuthDto = new RiderAuthDto(UUID.randomUUID(), existingEmail, "hashed-password");
+
+        given(riderService.findAuthDataByEmail(existingEmail)).willReturn(expectedAuthDto);
+
+        mockMvc.perform(get("/rider/internal/by-email")
+                        .param("email", existingEmail)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.email").value(existingEmail))
+                .andExpect(jsonPath("$.password").value("hashed-password"));
+    }
+
+    @Test
+    @DisplayName("Should return 404 Not Found when findAuthDataByEmail is called with a non-existing email")
+    void findAuthDataByEmail_withNonExistingEmail_shouldReturnNotFound() throws Exception {
+        String nonExistingEmail = "ghost@test.com";
+
+        given(riderService.findAuthDataByEmail(nonExistingEmail))
+                .willThrow(new ResourceNotFoundException("Rider", "e-mail", nonExistingEmail));
+
+        mockMvc.perform(get("/rider/internal/by-email")
+                        .param("email", nonExistingEmail)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
     }
 
 

--- a/rider-service/src/test/java/br/com/rastrodeliberdade/rider_service/service/RiderServiceTest.java
+++ b/rider-service/src/test/java/br/com/rastrodeliberdade/rider_service/service/RiderServiceTest.java
@@ -1,6 +1,7 @@
 package br.com.rastrodeliberdade.rider_service.service;
 
 import br.com.rastrodeliberdade.rider_service.domain.Rider;
+import br.com.rastrodeliberdade.rider_service.dto.RiderAuthDto;
 import br.com.rastrodeliberdade.rider_service.dto.RiderInsertDto;
 import br.com.rastrodeliberdade.rider_service.dto.RiderSummaryDto;
 import br.com.rastrodeliberdade.rider_service.exception.BusinessException;
@@ -441,6 +442,37 @@ public class RiderServiceTest {
 
         verify(riderRepository, times(1)).findById(idToDelete);
         verify(riderRepository, never()).delete(any(Rider.class));
+    }
+
+    @Test
+    @DisplayName("Should return RiderAuthDto when findAuthDataByEmail is called with an existing email")
+    void findAuthDataByEmail_withExistingEmail_shouldReturnRiderAuthDto() {
+        String existingEmail = existingRider.getEmail();
+
+
+        when(riderRepository.findByEmail(existingEmail)).thenReturn(Optional.of(existingRider));
+
+
+        RiderAuthDto result = riderService.findAuthDataByEmail(existingEmail);
+
+        assertThat(result).isNotNull();
+        assertThat(result.id()).isEqualTo(existingRider.getId());
+        assertThat(result.email()).isEqualTo(existingRider.getEmail());
+        assertThat(result.password()).isEqualTo(existingRider.getPassword());
+
+        verify(riderRepository, times(1)).findByEmail(existingEmail);
+
+    }
+
+    @Test
+    @DisplayName("Should throw ResourceNotFoundException when findAuthDataByEmail is called with a non-existing email")
+    void findAuthDataByEmail_withNonExistingEmail_shouldThrowResourceNotFoundException() {
+        String nonExistingEmail = "ghost@test.com";
+        when(riderRepository.findByEmail(nonExistingEmail)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> riderService.findAuthDataByEmail(nonExistingEmail))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("Rider não encontrado com e-mail: '" + nonExistingEmail + "'");
     }
 
 


### PR DESCRIPTION
## What does this PR do?
This PR prepares the `rider-service` for integration with the `auth-service` by creating a new, secure, internal-only endpoint. This endpoint is designed to expose the necessary authentication data (user ID, email, and hashed password) for a specific user, looked up by their email address.

## Why is this change necessary?
This is the first foundational step to enable real user authentication across the microservice architecture. To validate a user's credentials, the `auth-service` needs a secure mechanism to retrieve the corresponding hashed password from the `rider-service`, which is the source of truth for user data. This endpoint provides that mechanism.

